### PR TITLE
Import xs-opam-repo-6.96.0-1.xs8.src.rpm

### DIFF
--- a/SOURCES/xs-opam-repo-6.91.0.tar.gz
+++ b/SOURCES/xs-opam-repo-6.91.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ef034c79576b3b7be0735b6cb10339b31a8410428f6d713e787a5bad887f01f7
-size 23039576

--- a/SOURCES/xs-opam-repo-6.96.0-xcp-0.tar.gz
+++ b/SOURCES/xs-opam-repo-6.96.0-xcp-0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa26b2896ae739601ed49ee541708077dbcf548b3c0bf72dd07043e411bacdd1
+size 20195728

--- a/SOURCES/xs-opam-repo-6.96.0.tar.gz
+++ b/SOURCES/xs-opam-repo-6.96.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:374fef48de4720797fe899fab42e4c85f8bc8f98185b5374c552ea38c0863ce4
+size 20201201

--- a/SOURCES/xs-opam-repo-6.96.0.tar.gz
+++ b/SOURCES/xs-opam-repo-6.96.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:374fef48de4720797fe899fab42e4c85f8bc8f98185b5374c552ea38c0863ce4
-size 20201201

--- a/SPECS/xs-opam-repo.spec
+++ b/SPECS/xs-opam-repo.spec
@@ -92,7 +92,11 @@ export OPAMROOT=%{_opamroot}
 opam init --bare --no-setup -k local xs-opam . -y
 opam switch create ocaml-system
 
-PKG=$(opam exec -- opam list --installable --short)
+# take note of installed packages, along with their versions
+PKG_EXISTING=$(opam list --installed --short --separator=. --columns=name,version | tr -d ' ' | tr '\n' ',')
+
+# take note of packages that need to be installed. They have to be installable with already installed package versions, in particular with the current OCaml version.
+PKG=$(opam exec -- opam list --installable --short --coinstallable-with=$PKG_EXISTING)
 
 export OPAMFETCH=/bin/false
 opam exec -- opam install %{?_smp_mflags} -y $PKG

--- a/SPECS/xs-opam-repo.spec
+++ b/SPECS/xs-opam-repo.spec
@@ -1,5 +1,5 @@
-%global package_speccommit 10fe381a6eac75dcca62f4324b2008ddc92738d5
-%global usver 6.91.0
+%global package_speccommit 2a9ae47dd4adbc70893cc870c86ebf19c617bbe1
+%global usver 6.96.0
 %global xsver 1
 %global xsrel %{xsver}%{?xscount}%{?xshash}
 ## This has to match the declaration in xs-opam-src, which
@@ -10,7 +10,7 @@
 # However, something needs to be fixed on XS 9 to not need it anymore.
 %global _debugsource_template %{nil}
 
-%global _version 6.91.0
+%global _version 6.96.0
 
 # When building an untagged version, add the number of commits and hash after
 # the variable _version. e.g. -34-gab48a58c for 6.77.0-34-gab48a58c
@@ -25,7 +25,7 @@ Summary: Build and install OCaml libraries from Opam repository
 # keep these in sync.
 License: Apache-1.0 and Apache-2.0 and BSD-2-Clause and BSD-3-Clause and curl and GPL-1.0-or-later and GPL-2.0-only and GPL-2.0-or-later and GPL-3.0-only and GPL-3.0-or-later and ISC and LGPL-2.0-only WITH OCaml-LGPL-linking-exception and LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-only and LGPL-2.1-only WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OpenSSL-linking-exception and LGPL-3.0-only and MIT and PSF-2.0 and Unlicense
 URL:     https://github.com/xapi-project/xs-opam
-Source0: xs-opam-repo-6.91.0.tar.gz
+Source0: xs-opam-repo-6.96.0.tar.gz
 # To "pin" a package during development, see below the example
 # where ezxenstore is pinned to an internal master branch.
 # You need the Source1 line, and the below 'tar' and 'opam pin' lines, and comment-out the OPAMFETCH
@@ -65,6 +65,9 @@ BuildRequires: which
 BuildRequires: zlib-devel
 BuildRequires: libev-devel
 
+# needed for OCaml 5
+%global __ocaml_requires_opts -i Dynlink_cmo_format -i Dynlink_cmxs_format
+
 %description
 Opam repository that contains all libraries necessary to compile the
 Toolstack components of the Citrix Hypervisor.
@@ -86,7 +89,7 @@ export OPAMROOT=%{_opamroot}
 opam init --bare --no-setup -k local xs-opam . -y
 opam switch create ocaml-system
 
-PKG=$(opam exec -- opam list --available --short)
+PKG=$(opam exec -- opam list --installable --short)
 
 export OPAMFETCH=/bin/false
 opam exec -- opam install %{?_smp_mflags} -y $PKG
@@ -122,6 +125,12 @@ echo '%%_opamroot %%{_libdir}/opamroot' >> "%{buildroot}%{_rpmconfigdir}/macros.
 %{_opamroot}
 
 %changelog
+* Fri Oct 03 2025 Rob Hoes <rob.hoes@cloud.com> - 6.96.0-1
+- Add missing oxenstored dependencies
+
+* Wed Oct 01 2025 Rob Hoes <rob.hoes@cloud.com> - 6.95.0-1
+- Package updates for OCaml 5.3 compatibility
+
 * Fri Jul 18 2025 Rob Hoes <rob.hoes@cloud.com> - 6.91.0-1
 - Add qcow-stream and its dependencies
 - packages: update xen-api's metadata

--- a/SPECS/xs-opam-repo.spec
+++ b/SPECS/xs-opam-repo.spec
@@ -25,7 +25,7 @@ Summary: Build and install OCaml libraries from Opam repository
 # keep these in sync.
 License: Apache-1.0 and Apache-2.0 and BSD-2-Clause and BSD-3-Clause and curl and GPL-1.0-or-later and GPL-2.0-only and GPL-2.0-or-later and GPL-3.0-only and GPL-3.0-or-later and ISC and LGPL-2.0-only WITH OCaml-LGPL-linking-exception and LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-only and LGPL-2.1-only WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OpenSSL-linking-exception and LGPL-3.0-only and MIT and PSF-2.0 and Unlicense
 URL:     https://github.com/xapi-project/xs-opam
-Source0: xs-opam-repo-6.96.0.tar.gz
+Source0: xs-opam-repo-6.96.0-xcp-0.tar.gz
 # To "pin" a package during development, see below the example
 # where ezxenstore is pinned to an internal master branch.
 # You need the Source1 line, and the below 'tar' and 'opam pin' lines, and comment-out the OPAMFETCH
@@ -74,7 +74,7 @@ Opam repository that contains all libraries necessary to compile the
 Toolstack components of the Citrix Hypervisor.
 
 %prep
-%autosetup -p1 -n xs-opam-repo-%{_version_full}
+%autosetup -p1 -n xs-opam-repo-%{_version_full}-xcp-0
 # XCP-ng: remove dlm, which is only required by proprietary xapi-clusterd
 rm -r packages/dlm/dlm.*
 


### PR DESCRIPTION
A couple of patches were needed:
- rollback openssl library
- changes to adapt to the presence of OCaml-5-only packages with the newer opam version we're packaging

Test build can be found in https://koji.xcp-ng.org/taskinfo?taskID=92638