### PR TITLE
Rebuild with new ocaml, opam

### DIFF
--- a/SOURCES/xs-opam-repo-6.99.0-xcp-2.tar.gz
+++ b/SOURCES/xs-opam-repo-6.99.0-xcp-2.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02a0935fed37ac1cfa8ed8740c36bf03ecd40a23ceafb046cfbcbb123c473729
-size 19722292

--- a/SOURCES/xs-opam-repo-6.99.0-xcp-3.tar.gz
+++ b/SOURCES/xs-opam-repo-6.99.0-xcp-3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c41af87036f2005524b0cb443bbff4ebce93aa43f448ed2fec998a1a7395c119
+size 21650844

--- a/SPECS/xs-opam-repo.spec
+++ b/SPECS/xs-opam-repo.spec
@@ -18,14 +18,14 @@
 
 Name: xs-opam-repo
 Version: %{_version}
-Release: %{?xsrel}.4%{?dist}
+Release: %{?xsrel}.5%{?dist}
 Summary: Build and install OCaml libraries from Opam repository
 # The license field is produced by running print-license.sh
 # Please update licenses.txt on every new version and then run the script to
 # keep these in sync.
 License: Apache-1.0 and Apache-2.0 and BSD-2-Clause and BSD-3-Clause and curl and GPL-1.0-or-later and GPL-2.0-only and GPL-3.0-or-later and ISC and LGPL-2.0-only WITH OCaml-LGPL-linking-exception and LGPL-2.0-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-only and LGPL-2.1-only WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception and LGPL-2.1-or-later WITH OpenSSL-linking-exception and LGPL-3.0-only and MIT and PSF-2.0
 URL:     https://github.com/xapi-project/xs-opam
-Source0: xs-opam-repo-6.99.0-xcp-2.tar.gz
+Source0: xs-opam-repo-6.99.0-xcp-3.tar.gz
 # To "pin" a package during development, see below the example
 # where ezxenstore is pinned to an internal master branch.
 # You need the Source1 line, and the below 'tar' and 'opam pin' lines, and comment-out the OPAMFETCH
@@ -74,7 +74,7 @@ Opam repository that contains all libraries necessary to compile the
 Toolstack components of the Citrix Hypervisor.
 
 %prep
-%autosetup -p1 -n xs-opam-repo-%{_version_full}-xcp-2
+%autosetup -p1 -n xs-opam-repo-%{_version_full}-xcp-3
 # XCP-ng: remove dlm, which is only required by proprietary xapi-clusterd
 rm -r packages/dlm/dlm.*
 
@@ -133,10 +133,13 @@ echo '%%_opamroot %%{_libdir}/opamroot' >> "%{buildroot}%{_rpmconfigdir}/macros.
 %{_opamroot}
 
 %changelog
-* Fri Mar 6 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 6.99.0-1.4
+* Tue Jun 23 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 6.99.0-1.5
+- Rebuild with new ocaml, opam
+
+* Fri Mar 6 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 6.99.0-1.4
 - Update ocaml-qcow to fix bug with VDIs > 4tb
 
-* Fri Mar 6 2026 Andrii Sultanov <andriy-sultanov@vates.tech> - 6.99.0-1.3
+* Fri Mar 6 2026 Andrii Sultanov <andriy.sultanov@vates.tech> - 6.99.0-1.3
 - Update ocaml-qcow to 0.13.0
 
 * Fri Feb 20 2026 Philippe Coval <philippe.coval@vates.tech> - 6.99.0-1.2
@@ -170,7 +173,7 @@ echo '%%_opamroot %%{_libdir}/opamroot' >> "%{buildroot}%{_rpmconfigdir}/macros.
   * Wed Oct 01 2025 Rob Hoes <rob.hoes@cloud.com> - 6.95.0-1
   - Package updates for OCaml 5.3 compatibility
 
-* Wed Aug 06 2025 Andrii Sultanov <andriy-sultanov@vates.tech> - 6.91.0-1.1
+* Wed Aug 06 2025 Andrii Sultanov <andriy.sultanov@vates.tech> - 6.91.0-1.1
 - Update to 6.91.0-1
 - *** Upstream changelog ***
   * Fri Jul 18 2025 Rob Hoes <rob.hoes@cloud.com> - 6.91.0-1


### PR DESCRIPTION
### Main information

#### Work Item Reference

XCPNG-3422

#### Related changes (optional)

Needs to be built after the corresponding [`ocaml`](https://github.com/xcp-ng-rpms/ocaml/pull/2) and [`opam`](https://github.com/xcp-ng-rpms/opam/pull/4) PRs.

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

8.3-next

### Release Notes and Documentation

#### Explain the change to users

No user-facing changes

#### Documentation update needed

- [X] No

---

### Testing and regression avoidance

No testing is needed, this is a build dependency for xapi.

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [X] No